### PR TITLE
Trying to address FIPS issue with the observatorium service

### DIFF
--- a/main.go
+++ b/main.go
@@ -541,7 +541,7 @@ func parseFlags() (config, error) {
 	flag.StringVar(&cfg.tls.healthchecksServerName, "tls.healthchecks.server-name", "",
 		"Server name is used to verify the hostname of the certificates returned by the server."+
 			" If no server name is specified, the server name will be inferred from the healthcheck URL.")
-	flag.StringVar(&cfg.tls.minVersion, "tls.min-version", "VersionTLS13",
+	flag.StringVar(&cfg.tls.minVersion, "tls.min-version", "VersionTLS12",
 		"Minimum TLS version supported. Value must match version names from https://golang.org/pkg/crypto/tls/#pkg-constants.")
 	flag.StringVar(&rawTLSCipherSuites, "tls.cipher-suites", "",
 		"Comma-separated list of cipher suites for the server."+


### PR DESCRIPTION
FIPS CVE-2023-3089 requires TLS 1.2 only for OCP 4.10 and 4.11 since the TLS 1.3 ciphers have been submitted but not yet approved.  I think Observatorium should not work on these FIPS enabled environments when that CVE is fixed.  With this change I am hoping it would fix the issue.  This is based on a slack thread conversation though