### PR TITLE
Port over server timeout settings and config from upstream

### DIFF
--- a/internal/api/logs/v1/http.go
+++ b/internal/api/logs/v1/http.go
@@ -15,8 +15,7 @@ import (
 )
 
 const (
-	ReadTimeout        = 15 * time.Minute
-	WriteTimeout       = time.Minute
+	dialTimeout        = 30 * time.Second // Set as in http.DefaultTransport
 	lokiUpstreamPrefix = "/loki"
 )
 
@@ -103,7 +102,7 @@ func NewHandler(read, tail, write *url.URL, opts ...HandlerOption) http.Handler 
 				ErrorLog: proxy.Logger(c.logger),
 				Transport: &http.Transport{
 					DialContext: (&net.Dialer{
-						Timeout: ReadTimeout,
+						Timeout: dialTimeout,
 					}).DialContext,
 				},
 			}
@@ -136,7 +135,7 @@ func NewHandler(read, tail, write *url.URL, opts ...HandlerOption) http.Handler 
 				ErrorLog: proxy.Logger(c.logger),
 				Transport: &http.Transport{
 					DialContext: (&net.Dialer{
-						Timeout: ReadTimeout,
+						Timeout: dialTimeout,
 					}).DialContext,
 				},
 			}
@@ -165,7 +164,7 @@ func NewHandler(read, tail, write *url.URL, opts ...HandlerOption) http.Handler 
 				ErrorLog: proxy.Logger(c.logger),
 				Transport: &http.Transport{
 					DialContext: (&net.Dialer{
-						Timeout: WriteTimeout,
+						Timeout: dialTimeout,
 					}).DialContext,
 				},
 			}

--- a/internal/api/metrics/legacy/http.go
+++ b/internal/api/metrics/legacy/http.go
@@ -15,7 +15,7 @@ import (
 )
 
 const (
-	readTimeout = 15 * time.Minute
+	dialTimeout = 30 * time.Second // Set as in http.DefaultTransport
 )
 
 type handlerConfiguration struct {
@@ -88,7 +88,7 @@ func NewHandler(url *url.URL, opts ...HandlerOption) http.Handler {
 			ErrorLog: proxy.Logger(c.logger),
 			Transport: &http.Transport{
 				DialContext: (&net.Dialer{
-					Timeout: readTimeout,
+					Timeout: dialTimeout,
 				}).DialContext,
 			},
 		}

--- a/internal/api/metrics/v1/http.go
+++ b/internal/api/metrics/v1/http.go
@@ -16,8 +16,7 @@ import (
 )
 
 const (
-	readTimeout  = 15 * time.Minute
-	writeTimeout = time.Minute
+	dialTimeout = 30 * time.Second // Set as in http.DefaultTransport
 )
 
 type handlerConfiguration struct {
@@ -112,7 +111,7 @@ func NewHandler(read, write *url.URL, opts ...HandlerOption) http.Handler {
 				ErrorLog: proxy.Logger(c.logger),
 				Transport: &http.Transport{
 					DialContext: (&net.Dialer{
-						Timeout: readTimeout,
+						Timeout: dialTimeout,
 					}).DialContext,
 				},
 			}


### PR DESCRIPTION
https://issues.redhat.com/browse/ACM-9767

This is a port of https://github.com/observatorium/api/pull/511 and https://github.com/observatorium/api/pull/493