### PR TITLE
Use UBI9 in dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ WORKDIR /opt
 
 RUN git update-index --refresh; make observatorium
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal:latest AS runner
+FROM registry.access.redhat.com/ubi9/ubi-minimal:latest AS runner
 
 COPY --from=builder /opt/observatorium /bin/observatorium
 


### PR DESCRIPTION
Avoids:

```
/bin/observatorium: /lib64/libc.so.6: version GLIBC_2.34' not found (required by /bin/observatorium)
/bin/observatorium: /lib64/libc.so.6: version GLIBC_2.32' not found (required by /bin/observatorium)
```