### PR TITLE
Konflux: remove dup `IMAGE_DIGEST` param

### DIFF
--- a/.tekton/observatorium-acm-215-push.yaml
+++ b/.tekton/observatorium-acm-215-push.yaml
@@ -299,8 +299,6 @@ spec:
         value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
       - name: CACHI2_ARTIFACT
         value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
-      - name: BINARY_IMAGE_DIGEST
-        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
       runAfter:
       - build-image-index
       taskRef:


### PR DESCRIPTION
Causes Konflux not to build.