### PR TITLE
Konflux: another dup variable on push pipeline

### DIFF
--- a/.tekton/observatorium-acm-215-push.yaml
+++ b/.tekton/observatorium-acm-215-push.yaml
@@ -460,8 +460,6 @@ spec:
         value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
       - name: CACHI2_ARTIFACT
         value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
-      - name: image-digest
-        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
       runAfter:
       - coverity-availability-check
       taskRef:


### PR DESCRIPTION
Fixes:

```
Tekton Controller has reported this error: admission webhook "validation.webhook.pipeline.tekton.dev" denied the request: validation failed: parameter names must be unique, the parameter "image-digest" is also defined at: spec.pipelineSpec.tasks[11].params[13].name, spec[11].params[13].name
```