### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for observatorium-acm-214

### DIFF
--- a/Containerfile.operator
+++ b/Containerfile.operator
@@ -19,7 +19,8 @@ ARG VCS_REF
 ARG DOCKERFILE_PATH
 
 LABEL com.redhat.component="observatorium" \
-    name="observatorium/observatorium" \
+    name="rhacm2/observatorium-rhel9" \
+    cpe="cpe:/a:redhat:acm:2.14::el9" \
     summary="observatorium-acm" \
     description="Observatorium API" \
     io.openshift.tags="observability" \


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
