### PR TITLE
Security: Fix CVE-2026-27571 (nats-server) - main

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -59,8 +59,8 @@ require (
 )
 
 replace (
-	// fix CVE-2022-24450
-	github.com/nats-io/nats-server/v2 => github.com/nats-io/nats-server/v2 v2.7.2
+	// fix CVE-2022-24450, CVE-2026-27571
+	github.com/nats-io/nats-server/v2 => github.com/nats-io/nats-server/v2 v2.11.12
 	go.etcd.io/etcd => go.etcd.io/etcd v0.5.0-alpha.5.0.20200329194405-dd816f0735f8
 	google.golang.org/grpc => google.golang.org/grpc v1.79.3
 )

--- a/go.sum
+++ b/go.sum
@@ -3367,6 +3367,7 @@ github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f/go.mod h1:ZdcZmHo+
 github.com/nats-io/jwt v0.3.0/go.mod h1:fRYCDE99xlTsqUzISS1Bi75UBJ6ljOJQOAAu5VglpSg=
 github.com/nats-io/jwt/v2 v2.2.1-0.20220113022732-58e87895b296/go.mod h1:0tqz9Hlu6bCBFLWAASKhE5vUA4c24L9KPUUgvwumE/k=
 github.com/nats-io/nats-server/v2 v2.7.2/go.mod h1:tckmrt0M6bVaDT3kmh9UrIq/CBOBBse+TpXQi5ldaa8=
+github.com/nats-io/nats-server/v2 v2.11.12/go.mod h1:5MCp/pqm5SEfsvVZ31ll1088ZTwEUdvRX1Hmh/mTTDg=
 github.com/nats-io/nats.go v1.9.1/go.mod h1:ZjDU1L/7fJ09jvUSRVBR2e7+RnLiiIQyqyzEE/Zbp4w=
 github.com/nats-io/nats.go v1.13.1-0.20220121202836-972a071d373d/go.mod h1:BPko4oXsySz4aSWeFgOHLZs3G4Jq4ZAyE6/zMCxRT6w=
 github.com/nats-io/nkeys v0.1.0/go.mod h1:xpnFELMwJABBLVhffcfd1MZx6VsNRFpEugbxziKVo7w=

--- a/go.sum
+++ b/go.sum
@@ -3367,7 +3367,6 @@ github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f/go.mod h1:ZdcZmHo+
 github.com/nats-io/jwt v0.3.0/go.mod h1:fRYCDE99xlTsqUzISS1Bi75UBJ6ljOJQOAAu5VglpSg=
 github.com/nats-io/jwt/v2 v2.2.1-0.20220113022732-58e87895b296/go.mod h1:0tqz9Hlu6bCBFLWAASKhE5vUA4c24L9KPUUgvwumE/k=
 github.com/nats-io/nats-server/v2 v2.7.2/go.mod h1:tckmrt0M6bVaDT3kmh9UrIq/CBOBBse+TpXQi5ldaa8=
-github.com/nats-io/nats-server/v2 v2.11.12/go.mod h1:5MCp/pqm5SEfsvVZ31ll1088ZTwEUdvRX1Hmh/mTTDg=
 github.com/nats-io/nats.go v1.9.1/go.mod h1:ZjDU1L/7fJ09jvUSRVBR2e7+RnLiiIQyqyzEE/Zbp4w=
 github.com/nats-io/nats.go v1.13.1-0.20220121202836-972a071d373d/go.mod h1:BPko4oXsySz4aSWeFgOHLZs3G4Jq4ZAyE6/zMCxRT6w=
 github.com/nats-io/nkeys v0.1.0/go.mod h1:xpnFELMwJABBLVhffcfd1MZx6VsNRFpEugbxziKVo7w=


### PR DESCRIPTION
## Summary

This PR fixes **CVE-2026-27571** by updating the `nats-server/v2` replace directive from `v2.7.2` to `v2.11.12`.

### CVE Details
- **CVE ID**: CVE-2026-27571 / GO-2026-4533
- **Package**: github.com/nats-io/nats-server/v2
- **Severity**: HIGH (CVSS 7.5)
- **CWE**: CWE-770 / CWE-409 (Allocation of Resources Without Limits)
- **Impact**: WebSockets pre-auth memory DoS — attacker sends a compression bomb via WebSockets before authentication, causing excessive memory consumption and OS-level process termination
- **Vulnerable versions**: < 2.11.12 (also 2.12.0-RC.1 through < 2.12.3)
- **Fixed version**: 2.11.12
- **Jira Issues**: ACM-30425

### Fix Summary

Updated the `replace` directive in `go.mod`:

```diff
-  // fix CVE-2022-24450
-  github.com/nats-io/nats-server/v2 => github.com/nats-io/nats-server/v2 v2.7.2
+  // fix CVE-2022-24450, CVE-2026-27571
+  github.com/nats-io/nats-server/v2 => github.com/nats-io/nats-server/v2 v2.11.12
```

### Technical Context

`nats-server/v2` is a **transitive dependency** introduced via `github.com/go-kit/kit` (which optionally supports NATS transport). The `observatorium` binary does not import any `go-kit/transport/nats` packages, so the vulnerable WebSocket handling code is **not in the execute path**.

Evidence:
- `go mod why github.com/nats-io/nats-server/v2` → "main module does not need package"
- `govulncheck ./...` → does not report this CVE at symbol level (code not called)
- The `replace` directive is defense-in-depth to prevent the vulnerable module from being pulled in if imports change in the future

### Test Results

**Status**: ✅ PASSED

**Tests discovered**: Yes  
**Test command**: `go test ./...`  
**Exit code**: 0  
**Result**:
- `ok github.com/observatorium/observatorium/internal/remotewrite`
- `ok github.com/observatorium/observatorium/rbac`
- Build: `go build ./...` — successful

No test failures. All packages without test files confirmed skipped.

### Breaking Changes

None. This is a minor version bump (`v2.7.2` → `v2.11.12`) of a transitive dependency that is not compiled into the observatorium binary. The replace directive is a safety measure only.

### Verification Steps

- [ ] Confirm `go mod verify` passes
- [ ] Confirm `govulncheck` does not report CVE-2026-27571
- [ ] Confirm binary builds successfully
- [ ] Verify no nats-server WebSocket code is in the compiled binary: `govulncheck -mode binary ./observatorium`

### Risk Assessment

| Factor | Assessment |
|--------|------------|
| Risk level | **LOW** |
| Breaking changes | None |
| Test coverage | Unit tests pass |
| Rollback | Revert go.mod replace directive to v2.7.2 |

The replace directive update is safe — nats-server is not a runtime dependency of observatorium.

---

🤖 Generated by CVE Fixer Workflow  
<!-- cve-fixer-workflow -->