### PR TITLE
[ACM-30183] feat: add --tls.min-version arg on observatorium-api jsonnet

### DIFF
--- a/jsonnet/lib/observatorium-api.libsonnet
+++ b/jsonnet/lib/observatorium-api.libsonnet
@@ -168,6 +168,12 @@ function(params) {
                         '--tls.cipher-suites=' + api.config.tls.cipherSuites,
                       ]
                     else []
+                  ) + (
+                    if std.objectHas(api.config.tls, 'minVersion') then
+                      [
+                        '--tls.min-version=' + api.config.tls.minVersion,
+                      ]
+                    else []
                   )
                 else []
               ) + (


### PR DESCRIPTION
The go service already supports the `--tls.min-version` flag (defaulted to `VersionTLS12`) and the resulting TLS server configuration.
Added the jsonnet arg so the observatorium-operator or other consumers can personalize the flag