### PR TITLE
Bump Go builder to 1.26

### DIFF
--- a/Containerfile.operator
+++ b/Containerfile.operator
@@ -1,7 +1,7 @@
 # Copyright Contributors to the Open Cluster Management project
 # Licensed under the Apache License 2.0
 
-FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.25 AS builder
+FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.26 AS builder
 
 WORKDIR /opt
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/stolostron/builder:go1.25-linux AS builder
+FROM registry.ci.openshift.org/stolostron/builder:go1.26-linux AS builder
 
 ADD go.mod /opt/go.mod
 ADD go.sum /opt/go.sum


### PR DESCRIPTION
Bump openshift-golang-builder from rhel_9_1.25 to rhel_9_1.26 in Containerfile.operator and Dockerfile