### PR TITLE
ACM-41566: Switch to PQC base images

### DIFF
--- a/Containerfile.operator
+++ b/Containerfile.operator
@@ -9,7 +9,7 @@ COPY . .
 
 RUN git update-index --refresh; make observatorium
 
-FROM registry.access.redhat.com/ubi9/ubi-minimal:latest AS runner
+FROM registry.redhat.io/ubi9/ubi-minimal-pqc:latest AS runner
 
 COPY --from=builder /opt/observatorium /bin/observatorium
 


### PR DESCRIPTION
## Summary
- Switch runtime base images from `ubi9/ubi-minimal` to `ubi9/ubi-minimal-pqc` for post-quantum cryptography
- Part of [ACM-40663](https://redhat.atlassian.net/browse/ACM-40663) / [ACM-41566](https://redhat.atlassian.net/browse/ACM-41566)

## Test plan
- [ ] Verify Konflux builds succeed with the new base image
- [ ] Verify no regression in regular and FIPS modes

[ACM-40663]: https://redhat.atlassian.net/browse/ACM-40663?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ACM-41566]: https://redhat.atlassian.net/browse/ACM-41566?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ